### PR TITLE
Update entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,4 @@ USER method
 WORKDIR /opt/method/${CLI_NAME}/
 
 ENV PATH="/opt/method/${CLI_NAME}/service/bin:${PATH}"
+ENTRYPOINT [ "gitlabctl" ]


### PR DESCRIPTION
Updates entrypoint to be `gitlabctl` instead of the shell to ease usage